### PR TITLE
Dynamic click

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.7 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Added dynamic download link that is created from ajax.
+  [ivanteoh]
 
 
 1.6.1 (2017-08-22)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 1.7 (unreleased)
 ----------------
 
-- Added dynamic download link that is created from ajax.
+- Ensure download handler works even on links loaded from AJAX such as the quicksearch.
   [ivanteoh]
 
 

--- a/src/collective/googleanalytics/tracking/download.pt
+++ b/src/collective/googleanalytics/tracking/download.pt
@@ -3,10 +3,10 @@
     jQuery(function($) {
         var extensions = ${view/file_extensions};
         var extensionsPattern = new RegExp('\\.((' + extensions.join(')|(') + '))$', 'g');
-        $('a').filter(function () {
-            return this.href.match(extensionsPattern) || this.href.match(/\/at_download\//g);
-        }).click(function () {
-            _gaq.push(['_trackEvent', 'File', 'Download', $(this).attr('href')]);
+        $('body').delegate('a', 'click', function() {
+            if ($(this).attr('href').match(extensionsPattern) ||  $(this).attr('href').match(/\/at_download\//g)) {
+                _gaq.push(['_trackEvent', 'File', 'Download', $(this).attr('href')]);
+            }
         });
     });
     /*]]&gt;*/


### PR DESCRIPTION
partially fixes https://github.com/collective/collective.googleanalytics/issues/19 by adding the event handler to links even if they were generated by other javascript such as the quick search in plone.
